### PR TITLE
[TIKA-3420] Set tesseract ocr langauges as docker build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,34 @@ This repo is used to create convenience Docker images for Apache Tika Server pub
 
 The images create a functional Apache Tika Server instance that contains the latest Ubuntu running the appropriate version's server on Port 9998 using Java 8 (until version 1.20), Java 11 (1.21 and 1.24.1) and Java 14 for newer versions.
 
-There is a minimal version, which contains only Apache Tika and it's core dependencies, and a full version, which also includes dependencies for the GDAL and Tesseract OCR parsers. To balance showing functionality versus the size of the full image, this file currently installs the language packs for the following languages:
+There is a minimal version, which contains only Apache Tika and it's core dependencies, and a full version, which also includes dependencies for the GDAL and [Tesseract OCR parsers](#default-tesseract). To balance showing functionality versus the size of the full image, this file currently installs the language packs for the following languages:
+
 * English
 * French
 * German
 * Italian
 * Spanish.
 
-To install more languages simply update the apt-get command to include the package containing the language you required, or include your own custom packs using an ADD command.
+To install more languages simply use `docker-build.sh` or manually using [docker --build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)
+
+For see with version is supported by tesseract on official package:
+
+    apt-cache search --names-only '^tesseract-ocr-[a-z]{3}$'
 
 ## Available Tags
 
 Below are the most recent tags:
 
-- `latest`, `1.25`: Apache Tika Server 1.25 (Minimal)
-- `latest-full`, `1.25-full`: Apache Tika Server 1.25 (Full)
-- `1.25`: Apache Tika Server 1.25 (Minimal)
-- `1.25-full`: Apache Tika Server 1.25 (Full)
-- `1.24.1`: Apache Tika Server 1.24.1 (Minimal)
-- `1.24.1-full`: Apache Tika Server 1.24.1 (Full)
-- `1.24`: Apache Tika Server 1.24 (Minimal)
-- `1.24-full`: Apache Tika Server 1.24 (Full)
-- `1.23`: Apache Tika Server 1.23 (Minimal)
-- `1.23-full`: Apache Tika Server 1.23 (Full)
+* `latest`, `1.25`: Apache Tika Server 1.25 (Minimal)
+* `latest-full`, `1.25-full`: Apache Tika Server 1.25 (Full)
+* `1.25`: Apache Tika Server 1.25 (Minimal)
+* `1.25-full`: Apache Tika Server 1.25 (Full)
+* `1.24.1`: Apache Tika Server 1.24.1 (Minimal)
+* `1.24.1-full`: Apache Tika Server 1.24.1 (Full)
+* `1.24`: Apache Tika Server 1.24 (Minimal)
+* `1.24-full`: Apache Tika Server 1.24 (Full)
+* `1.23`: Apache Tika Server 1.23 (Minimal)
+* `1.23-full`: Apache Tika Server 1.23 (Full)
 
 You can see a full set of tags for historical versions [here](https://hub.docker.com/r/apache/tika/tags?page=1&ordering=last_updated).
 
@@ -42,7 +47,7 @@ Then to run the container, execute the following command:
 
     docker run -d -p 9998:9998 apache/tika:<tag>
 
-Where <tag> is the DockerHub tag corresponding to the Apache Tika Server version - e.g. 1.23, 1.22, 1.23-full, 1.22-full.
+Where `<tag>` is the DockerHub tag corresponding to the Apache Tika Server version - e.g. 1.23, 1.22, 1.23-full, 1.22-full.
 
 NOTE: The latest and latest-full tags are explicitly set to the latest released version when they are published.
 
@@ -52,18 +57,17 @@ From version 1.25 and 1.25-full of the image it is now easier to override the de
 
 So for example if you wish to disable the OCR parser in the full image you could write a custom configuration:
 
-```
-cat <<EOT >> tika-config.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<properties>
-  <parsers>
-      <parser class="org.apache.tika.parser.DefaultParser">
-          <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
-      </parser>
-  </parsers>
-</properties>
-EOT
-```
+    cat <<EOT >> tika-config.xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <properties>
+    <parsers>
+        <parser class="org.apache.tika.parser.DefaultParser">
+            <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
+        </parser>
+    </parsers>
+    </properties>
+    EOT
+
 Then by mounting this custom configuration as a volume, you could pass the command line parameter to load it
 
     docker run -d -p 9998:9998 -v `pwd`/tika-config.xml:/tika-config.xml apache/tika:1.25-full --config /tika-config.xml
@@ -90,11 +94,11 @@ You can install docker-compose from [here](https://docs.docker.com/compose/insta
 To build the image from scratch, simply invoke:
 
     docker build -t 'apache/tika' github.com/apache/tika-docker
-   
+
 You can then use the following command (using the name you allocated in the build command as part of -t option):
 
     docker run -d -p 9998:9998 apache/tika
-    
+
 ## More Information
 
 For more infomation on Apache Tika Server, go to the [Apache Tika Server documentation](http://wiki.apache.org/tika/TikaJAXRS).
@@ -106,15 +110,15 @@ For more information on the Apache Software Foundation, go to the [Apache Softwa
 ## Authors
 
 Apache Tika Dev Team (dev@tika.apache.org)
-   
+
 ## Contributors
 
 There have been a range of [contributors](https://github.com/apache/tika-docker/graphs/contributors) on GitHub and via suggestions, including:
 
-- [@grossws](https://github.com/grossws)
-- [@arjunyel](https://github.com/arjunyel)
-- [@mpdude](https://github.com/mpdude)
-- [@laszlocsontosuw](https://github.com/laszlocsontosuw)
+* [@grossws](https://github.com/grossws)
+* [@arjunyel](https://github.com/arjunyel)
+* [@mpdude](https://github.com/mpdude)
+* [@laszlocsontosuw](https://github.com/laszlocsontosuw)
 
 ## Licence
 
@@ -129,7 +133,7 @@ There have been a range of [contributors](https://github.com/apache/tika-docker/
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
- 
+
 ## Disclaimer
 
 It is worth noting that whilst these Docker images download the binary JARs published by the Apache Tika Team on the Apache Software Foundation distribution sites, only the source release of an Apache Software Foundation project is an official release artefact. See [Release Distribution Policy](https://www.apache.org/dev/release-distribution.html) for more details.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There is a minimal version, which contains only Apache Tika and it's core depend
 
 To install more languages simply use `docker-build.sh` or manually using [docker --build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)
 
-For see with version is supported by tesseract on official package:
+Obtain a list of official Tesseract packages by executing (on Linux):
 
     apt-cache search --names-only '^tesseract-ocr-[a-z]{3}$'
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This repo is used to create convenience Docker images for Apache Tika Server pub
 
 The images create a functional Apache Tika Server instance that contains the latest Ubuntu running the appropriate version's server on Port 9998 using Java 8 (until version 1.20), Java 11 (1.21 and 1.24.1) and Java 14 for newer versions.
 
-There is a minimal version, which contains only Apache Tika and it's core dependencies, and a full version, which also includes dependencies for the GDAL and [Tesseract OCR parsers](#default-tesseract). To balance showing functionality versus the size of the full image, this file currently installs the language packs for the following languages:
-
+There is a minimal version, which contains only Apache Tika and it's core dependencies, and a full version, which also includes dependencies for the GDAL and Tesseract OCR parsers. To balance showing functionality versus the size of the full image, this file currently installs the language packs for the following languages:
 * English
 * French
 * German
@@ -45,7 +44,7 @@ Then to run the container, execute the following command:
 
     docker run -d -p 9998:9998 apache/tika:<tag>
 
-Where `<tag>` is the DockerHub tag corresponding to the Apache Tika Server version - e.g. 1.23, 1.22, 1.23-full, 1.22-full.
+Where <tag> is the DockerHub tag corresponding to the Apache Tika Server version - e.g. 1.23, 1.22, 1.23-full, 1.22-full.
 
 NOTE: The latest and latest-full tags are explicitly set to the latest released version when they are published.
 
@@ -55,17 +54,18 @@ From version 1.25 and 1.25-full of the image it is now easier to override the de
 
 So for example if you wish to disable the OCR parser in the full image you could write a custom configuration:
 
-    cat <<EOT >> tika-config.xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <properties>
-    <parsers>
-        <parser class="org.apache.tika.parser.DefaultParser">
-            <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
-        </parser>
-    </parsers>
-    </properties>
-    EOT
-
+```
+cat <<EOT >> tika-config.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<properties>
+  <parsers>
+      <parser class="org.apache.tika.parser.DefaultParser">
+          <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
+      </parser>
+  </parsers>
+</properties>
+EOT
+```
 Then by mounting this custom configuration as a volume, you could pass the command line parameter to load it
 
     docker run -d -p 9998:9998 -v `pwd`/tika-config.xml:/tika-config.xml apache/tika:1.25-full --config /tika-config.xml
@@ -92,11 +92,11 @@ You can install docker-compose from [here](https://docs.docker.com/compose/insta
 To build the image from scratch, simply invoke:
 
     docker build -t 'apache/tika' github.com/apache/tika-docker
-
+   
 You can then use the following command (using the name you allocated in the build command as part of -t option):
 
     docker run -d -p 9998:9998 apache/tika
-
+    
 ## More Information
 
 For more infomation on Apache Tika Server, go to the [Apache Tika Server documentation](https://cwiki.apache.org/confluence/display/TIKA/TikaServer).
@@ -108,15 +108,15 @@ For more information on the Apache Software Foundation, go to the [Apache Softwa
 ## Authors
 
 Apache Tika Dev Team (dev@tika.apache.org)
-
+   
 ## Contributors
 
 There have been a range of [contributors](https://github.com/apache/tika-docker/graphs/contributors) on GitHub and via suggestions, including:
 
-* [@grossws](https://github.com/grossws)
-* [@arjunyel](https://github.com/arjunyel)
-* [@mpdude](https://github.com/mpdude)
-* [@laszlocsontosuw](https://github.com/laszlocsontosuw)
+- [@grossws](https://github.com/grossws)
+- [@arjunyel](https://github.com/arjunyel)
+- [@mpdude](https://github.com/mpdude)
+- [@laszlocsontosuw](https://github.com/laszlocsontosuw)
 
 ## Licence
 
@@ -131,7 +131,7 @@ There have been a range of [contributors](https://github.com/apache/tika-docker/
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
+ 
 ## Disclaimer
 
 It is worth noting that whilst these Docker images download the binary JARs published by the Apache Tika Team on the Apache Software Foundation distribution sites, only the source release of an Apache Software Foundation project is an official release artefact. See [Release Distribution Policy](https://www.apache.org/dev/release-distribution.html) for more details.

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -21,11 +21,11 @@ while getopts ":h" opt; do
   case ${opt} in
     h )
       echo "Usage:"
-      echo "    docker-tool.sh -h                                              Display this help message."
-      echo "    docker-tool.sh build <TIKA_VERSION> [<TESSERACT_LANGUAGES>]    Builds images for <TIKA_VERSION> via special [<TESSERACT_LANGUAGES>]."
-      echo "    docker-tool.sh test <TIKA_VERSION>                             Tests images for <TIKA_VERSION>."
-      echo "    docker-tool.sh publish <TIKA_VERSION>                          Publishes images for <TIKA_VERSION> to Docker Hub."
-      echo "    docker-tool.sh latest <TIKA_VERSION>                           Tags images for <TIKA_VERSION> as latest on Docker Hub."
+      echo "    docker-tool.sh -h                                            Display this help message."
+      echo "    docker-tool.sh build <TIKA_VERSION> [<TESSERACT_LANGUAGES>]  Builds images for <TIKA_VERSION> via special [<TESSERACT_LANGUAGES>]."
+      echo "    docker-tool.sh test <TIKA_VERSION>                           Tests images for <TIKA_VERSION>."
+      echo "    docker-tool.sh publish <TIKA_VERSION>                        Publishes images for <TIKA_VERSION> to Docker Hub."
+      echo "    docker-tool.sh latest <TIKA_VERSION>                         Tags images for <TIKA_VERSION> as latest on Docker Hub."
       echo ""
       echo "Note: [<TESSERACT_LANGUAGES>] is optional for full image,"
       echo "      to customize various tesseract-ocr packages. Otherwise the default packages are installed."
@@ -64,14 +64,19 @@ version=$1; shift
 jar=$1; shift
 tesseract_languages=$@
 
+if [ -z "$jar" ]
+then
+  jar="tika-server"
+fi
+
 case "$subcommand" in
   build)
-    build_args="--build-arg TIKA_VERSION=${version}"
+    build_args="--build-arg TIKA_VERSION=${version} --build-arg TIKA_JAR_NAME=${jar}"
     if [[ ! -z "$tesseract_languages" ]]; then
       build_args="$build_args --build-arg TESSERACT_LANGUAGES='${tesseract_languages}'"
     fi
     # Build slim version with minimal dependencies
-    docker build -t apache/tika:${version} --build-arg TIKA_VERSION=${version} - < minimal/Dockerfile --no-cache
+    docker build -t apache/tika:${version} ${build_args} - < minimal/Dockerfile --no-cache
     # Build full version with OCR, Fonts and GDAL
     docker build -t apache/tika:${version}-full ${build_args} - < full/Dockerfile --no-cache
     ;;

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -76,7 +76,7 @@ case "$subcommand" in
       build_args="$build_args --build-arg TESSERACT_LANGUAGES='${tesseract_languages}'"
     fi
     # Build slim version with minimal dependencies
-    # eval "docker build -t apache/tika:${version} ${build_args} - < minimal/Dockerfile --no-cache"
+    eval "docker build -t apache/tika:${version} ${build_args} - < minimal/Dockerfile --no-cache"
     # Build full version with OCR, Fonts and GDAL
     eval "docker build -t apache/tika:${version}-full ${build_args} - < full/Dockerfile"
     ;;

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -76,9 +76,9 @@ case "$subcommand" in
       build_args="$build_args --build-arg TESSERACT_LANGUAGES='${tesseract_languages}'"
     fi
     # Build slim version with minimal dependencies
-    docker build -t apache/tika:${version} ${build_args} - < minimal/Dockerfile --no-cache
+    # eval "docker build -t apache/tika:${version} ${build_args} - < minimal/Dockerfile --no-cache"
     # Build full version with OCR, Fonts and GDAL
-    docker build -t apache/tika:${version}-full ${build_args} - < full/Dockerfile --no-cache
+    eval "docker build -t apache/tika:${version}-full ${build_args} - < full/Dockerfile"
     ;;
 
   test)

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -78,7 +78,7 @@ case "$subcommand" in
     # Build slim version with minimal dependencies
     eval "docker build -t apache/tika:${version} ${build_args} - < minimal/Dockerfile --no-cache"
     # Build full version with OCR, Fonts and GDAL
-    eval "docker build -t apache/tika:${version}-full ${build_args} - < full/Dockerfile"
+    eval "docker build -t apache/tika:${version}-full ${build_args} - < full/Dockerfile --no-cache"
     ;;
 
   test)

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -61,6 +61,7 @@ test_docker_image() {
 shift $((OPTIND -1))
 subcommand=$1; shift
 version=$1; shift
+jar=$1; shift
 tesseract_languages=$@
 
 case "$subcommand" in

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -22,12 +22,13 @@ while getopts ":h" opt; do
     h )
       echo "Usage:"
       echo "    docker-tool.sh -h                                              Display this help message."
-      echo "    docker-tool.sh build <TIKA_VERSION> ['<TESSERACT_LANGUAGES>']  Builds images for <TIKA_VERSION> via special [<TESSERACT_LANGUAGES>]."
+      echo "    docker-tool.sh build <TIKA_VERSION> [<TESSERACT_LANGUAGES>]    Builds images for <TIKA_VERSION> via special [<TESSERACT_LANGUAGES>]."
       echo "    docker-tool.sh test <TIKA_VERSION>                             Tests images for <TIKA_VERSION>."
       echo "    docker-tool.sh publish <TIKA_VERSION>                          Publishes images for <TIKA_VERSION> to Docker Hub."
       echo "    docker-tool.sh latest <TIKA_VERSION>                           Tags images for <TIKA_VERSION> as latest on Docker Hub."
       echo ""
-      ecgi "Note: [<TESSERACT_LANGUAGES>] is optional for full image, if you want to change default `tesseract-ocr` installation languages."
+      echo "Note: [<TESSERACT_LANGUAGES>] is optional for full image,"
+      echo "      for change default tesseract-ocr packages."
       exit 0
       ;;
    \? )
@@ -60,7 +61,7 @@ test_docker_image() {
 shift $((OPTIND -1))
 subcommand=$1; shift
 version=$1; shift
-tesseract_languages=$1; shift
+tesseract_languages=$@
 
 case "$subcommand" in
   build)

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -28,7 +28,7 @@ while getopts ":h" opt; do
       echo "    docker-tool.sh latest <TIKA_VERSION>                           Tags images for <TIKA_VERSION> as latest on Docker Hub."
       echo ""
       echo "Note: [<TESSERACT_LANGUAGES>] is optional for full image,"
-      echo "      for change default tesseract-ocr packages."
+      echo "      to customize various tesseract-ocr packages. Otherwise the default packages are installed."
       exit 0
       ;;
    \? )

--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-get update
 
 FROM base as dependencies
 ARG JRE='openjdk-14-jre-headless'
+ARG TESSERACT_LANGUAGES='tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu'
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE gdal-bin tesseract-ocr \
-        tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE gdal-bin tesseract-ocr $TESSERACT_LANGUAGES
 
 RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y xfonts-utils fonts-freefont-ttf fonts-liberation ttf-mscorefonts-installer wget cabextract


### PR DESCRIPTION
Ability to user build docker with list of `tesseract-ocr-[lang]` as build args.