### PR TITLE
[TIKA-3417] Running tika-docker as non-root user

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update
 
 FROM base as dependencies
 ARG JRE='openjdk-14-jre-headless'
+# "random" uid/gid hopefully not used anywhere else
+ARG UID_GID="35002:35002"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE gdal-bin tesseract-ocr \
         tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
@@ -47,7 +49,7 @@ RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
-
+USER $UID_GID
 EXPOSE 9998
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0 $0 $@"]
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,3 +1,4 @@
+
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
@@ -14,7 +15,8 @@ RUN apt-get update
 
 FROM base as dependencies
 ARG JRE='openjdk-14-jre-headless'
-
+# "random" uid/gid hopefully not used anywhere else
+ARG UID_GID="35002:35002"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE
 
 FROM dependencies as fetch_tika
@@ -43,7 +45,7 @@ RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
-
+USER $UID_GID
 EXPOSE 9998
 ENTRYPOINT [ "/bin/sh", "-c", "exec java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0 $0 $@"]
 


### PR DESCRIPTION
Adding a configurable UID:GID for the tika process to run as so it doesn't run as root. The following tests still pass after this change.

```
$ ./docker-tool.sh build 1.26
$ ./docker-tool.sh test 1.26
2be3cb0532d10f4a4efa163d856dd72738d8acd2e625a4668c270e350d7d5135
Image: apache/tika:1.26 - Passed
1.26
1.26
60411633a11e85fcfce0e1f61c34f40f0ff89dc01faae69310a2b1ca2c3ece38
Image: apache/tika:1.26-full - Passed
1.26-full
1.26-full
```