### PR TITLE
Reduce apt leftovers present in image

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -16,25 +16,9 @@
 ARG UID_GID="35002:35002"
 
 FROM ubuntu:jammy as base
-RUN apt-get update
-# tesseract 5 is not yet in the base repo
-RUN apt-get -y install software-properties-common
-RUN add-apt-repository -y ppa:alex-p/tesseract-ocr5
 
+FROM base as fetch_tika
 
-FROM base as dependencies
-
-ARG UID_GID
-ARG JRE='openjdk-17-jre-headless'
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE gdal-bin tesseract-ocr \
-        tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
-
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y xfonts-utils fonts-freefont-ttf fonts-liberation ttf-mscorefonts-installer wget cabextract
-
-FROM dependencies as fetch_tika
-ARG UID_GID
 ARG TIKA_VERSION
 ARG CHECK_SIG=true
 
@@ -45,7 +29,7 @@ ENV NEAREST_TIKA_SERVER_URL="https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-
     ARCHIVE_TIKA_SERVER_ASC_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc" \
     TIKA_VERSION=$TIKA_VERSION
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 wget \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install gnupg2 wget ca-certificates \
     && wget -t 10 --max-redirect 1 --retry-connrefused -qO- https://downloads.apache.org/tika/KEYS | gpg --import \
     && wget -t 10 --max-redirect 1 --retry-connrefused $NEAREST_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
     && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || wget $ARCHIVE_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
@@ -57,9 +41,32 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 wget \
 
 RUN if [ "$CHECK_SIG" = "true" ] ; then gpg --verify /tika-server-standard-${TIKA_VERSION}.jar.asc /tika-server-standard-${TIKA_VERSION}.jar; fi
 
-FROM dependencies as runtime
+FROM base as runtime
 ARG UID_GID
-RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ARG JRE='openjdk-17-jre-headless'
+RUN set -eux \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends gnupg2 software-properties-common \
+    && add-apt-repository -y ppa:alex-p/tesseract-ocr5 \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends $JRE \
+        gdal-bin \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+        tesseract-ocr-ita \
+        tesseract-ocr-fra \
+        tesseract-ocr-spa \
+        tesseract-ocr-deu \
+    && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        xfonts-utils \
+        fonts-freefont-ttf \
+        fonts-liberation \
+        ttf-mscorefonts-installer \
+        wget \
+        cabextract \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -17,19 +17,9 @@
 ARG UID_GID="35002:35002"
 
 FROM ubuntu:jammy as base
-RUN apt-get update
 
-FROM base as dependencies
+FROM base as fetch_tika
 
-# must reference uid_gid
-ARG UID_GID
-ARG JRE='openjdk-17-jre-headless'
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install $JRE
-
-FROM dependencies as fetch_tika
-# must reference uid_gid
-ARG UID_GID
 ARG TIKA_VERSION
 ARG CHECK_SIG=true
 
@@ -40,7 +30,12 @@ ENV NEAREST_TIKA_SERVER_URL="https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-
     ARCHIVE_TIKA_SERVER_ASC_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc" \
     TIKA_VERSION=$TIKA_VERSION
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 wget \
+RUN set -eux \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        gnupg2 \
+        wget \
+        ca-certificates \
     && wget -t 10 --max-redirect 1 --retry-connrefused -qO- https://downloads.apache.org/tika/KEYS | gpg --import \
     && wget -t 10 --max-redirect 1 --retry-connrefused $NEAREST_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
     && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || wget $ARCHIVE_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
@@ -52,10 +47,16 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 wget \
 
 RUN if [ "$CHECK_SIG" = "true" ] ; then gpg --verify /tika-server-standard-${TIKA_VERSION}.jar.asc /tika-server-standard-${TIKA_VERSION}.jar; fi
 
-FROM dependencies as runtime
+FROM base as runtime
 # must reference uid_gid
 ARG UID_GID
-RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+ARG JRE='openjdk-17-jre-headless'
+RUN set -eux \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ${JRE} \
+        ca-certificates \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ARG TIKA_VERSION
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-standard-${TIKA_VERSION}.jar /tika-server-standard-${TIKA_VERSION}.jar


### PR DESCRIPTION
This PR aims to simplify the multi-stage building and reduce the apt caching which was left over in the image, resulting in a smaller image size.

As Docker images use an overlay file system, removing file(s) which were created in one layer from a different layer doesn't remove the file's size from the final image, just removes the file from being visible essentially.  

So now the `runtime` stage installs necessary packages and does the apt clean and cache removal in the same step, instead of trying to cleanup what `dependencies` added to the image.  The `fetch_tika` stage does just that still.  No removal of apt packages or caching matters here, as only the jar is copied to `runtime`.

Building manually and running `docker image ls` shows around a 50MB reduction in image size compared to the original.