### PR TITLE
Adds a minimal image based on Alpine instead of Ubuntu

### DIFF
--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -76,20 +76,24 @@ tika_version=$1; shift
 case "$subcommand" in
   build)
     # Build slim tika- with minimal dependencies
-    docker build -t apache/tika:${tika_docker_version} --build-arg TIKA_VERSION=${tika_version} - < minimal/Dockerfile --no-cache
+    docker build --tag apache/tika:${tika_docker_version} --build-arg TIKA_VERSION=${tika_version} - < minimal/Dockerfile --no-cache --progress simple
+    # Build slim tika- with minimal dependencies and Alpine base
+    docker build --tag apache/tika:${tika_docker_version}-alpine --build-arg TIKA_VERSION=${tika_version} - < minimal/alpine.dockerfile --no-cache --progress simple
     # Build full tika- with OCR, Fonts and GDAL
-    docker build -t apache/tika:${tika_docker_version}-full --build-arg TIKA_VERSION=${tika_version} - < full/Dockerfile --no-cache
+    docker build --tag apache/tika:${tika_docker_version}-full --build-arg TIKA_VERSION=${tika_version} - < full/Dockerfile --no-cache --progress simple
     ;;
 
   test)
     # Test the images
     test_docker_image ${tika_docker_version}
+    test_docker_image ${tika_docker_version}-alpine
     test_docker_image "${tika_docker_version}-full"
     ;;
 
   publish)
-    # Push the build images
+    # Push the built images
     docker push apache/tika:${tika_docker_version}
+    docker push apache/tika:${tika_docker_version}-alpine
     docker push apache/tika:${tika_docker_version}-full
     ;;
 
@@ -97,6 +101,8 @@ case "$subcommand" in
     # Update the latest tags to point to supplied tika-
     docker tag apache/tika:${tika_docker_version} apache/tika:latest
     docker push apache/tika:latest
+    docker tag apache/tika:${tika_docker_version}-alpine apache/tika:latest-alpine
+    docker push apache/tika:latest-alpine
     docker tag apache/tika:${tika_docker_version}-full apache/tika:latest-full
     docker push apache/tika:latest-full
     ;;

--- a/minimal/alpine.dockerfile
+++ b/minimal/alpine.dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.18 as base
+
+FROM base as fetch_tika
+ARG TIKA_VERSION
+ARG CHECK_SIG=true
+
+ENV NEAREST_TIKA_SERVER_URL="https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" \
+    ARCHIVE_TIKA_SERVER_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" \
+    BACKUP_TIKA_SERVER_URL="https://downloads.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" \
+    DEFAULT_TIKA_SERVER_ASC_URL="https://downloads.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc" \
+    ARCHIVE_TIKA_SERVER_ASC_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc" \
+    TIKA_VERSION=$TIKA_VERSION
+
+RUN apk add --no-cache \
+        gnupg \
+        wget \
+        ca-certificates \
+    && wget --quiet -t 10 --max-redirect 1 --retry-connrefused -qO- https://downloads.apache.org/tika/KEYS | gpg --import \
+    && wget --quiet -t 10 --max-redirect 1 --retry-connrefused $NEAREST_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || wget --quiet $ARCHIVE_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || wget --quiet $BACKUP_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || exit 1 \
+    && wget --quiet -t 10 --max-redirect 1 --retry-connrefused $DEFAULT_TIKA_SERVER_ASC_URL -O /tika-server-standard-${TIKA_VERSION}.jar.asc  || rm /tika-server-standard-${TIKA_VERSION}.jar.asc \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar.asc ]" || wget --quiet $ARCHIVE_TIKA_SERVER_ASC_URL -O /tika-server-standard-${TIKA_VERSION}.jar.asc || rm /tika-server-standard-${TIKA_VERSION}.jar.asc \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar.asc ]" || exit 1;
+
+RUN if [ "$CHECK_SIG" = "true" ] ; then gpg --verify /tika-server-standard-${TIKA_VERSION}.jar.asc /tika-server-standard-${TIKA_VERSION}.jar; fi
+
+FROM base as runtime
+ARG UID_GID="35002:35002"
+
+ARG JRE='openjdk17-jre-headless'
+ARG TIKA_VERSION
+
+ENV TIKA_VERSION=$TIKA_VERSION
+
+COPY --from=fetch_tika /tika-server-standard-${TIKA_VERSION}.jar /tika-server-standard-${TIKA_VERSION}.jar
+
+RUN apk add --no-cache \
+        $JRE
+
+USER $UID_GID
+EXPOSE 9998
+ENTRYPOINT [ "/bin/ash", "-c", "exec java -cp \"/tika-server-standard-${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
+
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org"


### PR DESCRIPTION
[Alpine Linux](https://www.alpinelinux.org/) is a popular base for a minimal sized Docker image.  This PR adds a Tika image based on Alpine, installing the same packages as the existing minimal.

The resulting built image saves about 100MB over the minimal image:
```
apache/tika   2.8.0-full     2dd99024e20e   About a minute ago   695MB
apache/tika   2.8.0-alpine   9e4cc612335e   7 minutes ago        265MB
apache/tika   2.8.0          c8376c42ca86   8 minutes ago        362MB
```

I've integrated it into the build script with the suffix of `-alpine`.  It could also be a prefix or `apache/tika-alpine:x.x.x`, etc.