### PR TITLE
Add Japanese tesseract ocr language pack.

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -57,6 +57,7 @@ RUN set -eux \
         tesseract-ocr-fra \
         tesseract-ocr-spa \
         tesseract-ocr-deu \
+        tesseract-ocr-jpn \
     && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
         xfonts-utils \


### PR DESCRIPTION
Could you add Japanese support for ocr in Tika Full image?
If I run it on Kubernetes, it's difficult to install it after boot container automatically.
