### PR TITLE
Added ImageMagick to support OCR image preprocessing

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -57,6 +57,7 @@ RUN set -eux \
         tesseract-ocr-fra \
         tesseract-ocr-spa \
         tesseract-ocr-deu \
+        imagemagick \
     && echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
         xfonts-utils \


### PR DESCRIPTION
Tesseract OCR image preprocessor is broken in the current Docker image because ImageMagick is missing.

You can reproduce this by setting `enableImagePreprocessing` in tika-config.xml:
```xml
  <?xml version="1.0" encoding="UTF-8"?>
  <properties>
    <parsers>
      <parser class="org.apache.tika.parser.DefaultParser">
        <parser-exclude class="org.apache.tika.parser.ocr.TesseractOCRParser"/>
      </parser>
      <parser class="org.apache.tika.parser.ocr.TesseractOCRParser">
        <params>
          <param name="enableImagePreprocessing" type="bool">true</param>
        </params>
      </parser>
    </parsers>
  </properties>
```

When you try to process a document, you'll get this error:
```
org.apache.tika.parser.ocr.TesseractOCRParser User has selected to preprocess images, but I can't find ImageMagick.Backing off to original file.
```