### PR TITLE
fix literal dollar sign

### DIFF
--- a/docker-compose-tika-customocr.yml
+++ b/docker-compose-tika-customocr.yml
@@ -20,7 +20,7 @@ services:
   tika:
     image: apache/tika:${TAG}-full
     # Override default so we can add configuration on classpath
-    entrypoint: [ "/bin/sh", "-c", "exec java -cp \"/customocr:/tika-server-standard-${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $$0 $$@"]
+    entrypoint: [ "/bin/sh", "-c", "exec java -cp \"/customocr:/tika-server-standard-$${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $$0 $$@"]
     # Kept command as example but could be added to entrypoint too
     command: -c /tika-config.xml
     restart: on-failure

--- a/docker-compose-tika-grobid.yml
+++ b/docker-compose-tika-grobid.yml
@@ -20,7 +20,7 @@ services:
   tika:
     image: apache/tika:${TAG}-full
     # Override default so we can add configuration on classpath
-    entrypoint: [ "/bin/sh", "-c", "exec java -cp \"/grobid:/tika-server-standard-${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $$0 $$@"]
+    entrypoint: [ "/bin/sh", "-c", "exec java -cp \"/grobid:/tika-server-standard-$${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $$0 $$@"]
     # Kept command as example but could be added to entrypoint too
     command: -c /grobid/tika-config.xml
     restart: on-failure


### PR DESCRIPTION
Fixing docker compose dollar sign literal

Bash environment variable TIKA_VERSION is not used in entrypoint definition because no interpolation is in effect.
This commit wil solve the following issue: https://issues.apache.org/jira/browse/TIKA-4407

References:
- https://docs.docker.com/reference/compose-file/interpolation/