### PR TITLE
TIKA-4611 Support s390x architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ Below are the most recent 1.x series tags. **Note** that as of 30 September 2022
 
 You can see a full set of tags for historical versions [here](https://hub.docker.com/r/apache/tika/tags?page=1&ordering=last_updated).
 
+## Supported Platforms
+
+The Docker images are published as multi-platform images supporting the following architectures:
+
+- `linux/amd64` - 64-bit x86 processors (Intel/AMD)
+- `linux/arm/v7` - 32-bit ARM processors
+- `linux/arm64/v8` - 64-bit ARM processors (Apple Silicon, AWS Graviton, etc.)
+- `linux/s390x` - IBM System z mainframes
+
+Docker will automatically pull the correct image for your platform when you use `docker pull` or `docker run`.
+
 ## Usage
 
 ### Default

--- a/docker-tool.sh
+++ b/docker-tool.sh
@@ -121,9 +121,9 @@ case "$subcommand" in
   publish)
     docker buildx create --use --name tika-builder || die "couldn't create builder"
     # Build multi-arch with buildx and push
-    docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --output "type=image,push=true" \
+    docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64,linux/s390x --output "type=image,push=true" \
       --tag ${image_name}:latest --tag ${image_name}:${tika_docker_version} --build-arg TIKA_VERSION=${tika_version} --no-cache --builder tika-builder minimal || stop_and_die "couldn't build multi-arch minimal"
-    docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --output "type=image,push=true" \
+    docker buildx build --platform linux/arm/v7,linux/arm64/v8,linux/amd64,linux/s390x --output "type=image,push=true" \
       --tag ${image_name}:latest-full --tag ${image_name}:${tika_docker_version}-full --build-arg TIKA_VERSION=${tika_version} --no-cache --builder tika-builder full || stop_and_die "couldn't build multi-arch full"
     docker buildx rm tika-builder || die "couldn't stop builder -- make sure to stop the builder manually! "
     ;;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/TIKA-4611

I did a test push to my own hub https://hub.docker.com/r/cominvent/apache-tika/tags and confirmed that an explicit `docker run --rm -ti --platform linux/s390x cominvent/apache-tika:test` pulls the image and that Tika runs under emulation on my mac. When running without the `--platform` argument, Tika starts much much faster, indicating the differece between emulated and not. I did not find an explicit way to have the docker command print that it is running emulation...