### PR TITLE
Build on resolute instead of plucky.

### DIFF
--- a/full/Dockerfile
+++ b/full/Dockerfile
@@ -15,7 +15,7 @@
 # the subsequent stages -- see TIKA-3912
 ARG UID_GID="35002:35002"
 
-FROM ubuntu:plucky AS base
+FROM ubuntu:resolute AS base
 
 FROM base AS fetch_tika
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -16,7 +16,7 @@
 # the subsequent stages -- see TIKA-3912
 ARG UID_GID="35002:35002"
 
-FROM ubuntu:plucky AS base
+FROM ubuntu:resolute AS base
 
 FROM base AS fetch_tika
 


### PR DESCRIPTION
This moves the build base from plucky to resolute.

Ubuntu plucky is EOL since mid January.
https://discourse.ubuntu.com/t/ubuntu-25-04-plucky-puffin-reached-end-of-life-on-15th-january-2026/75079/1